### PR TITLE
make `--config-path` work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.39.5 (October 09, 2019)
+
+- fix: stop a not existed web should exit normally
+- feat: make `--config-path` work again #172
+- refact: read forge relative path from forge config file(forge_release.toml)
+
 ## 0.39.5 (October 08, 2019)
 
 - feat: support `defaults` global config #264

--- a/src/cli/node/join/join.js
+++ b/src/cli/node/join/join.js
@@ -9,7 +9,7 @@ const get = require('lodash/get');
 const set = require('lodash/set');
 const GraphQLClient = require('@arcblock/graphql-client');
 const { config, ensureConfigComment } = require('core/env');
-const { getChainKeyFilePath } = require('core/forge-fs');
+const { readChainKeyFilePath } = require('core/forge-fs');
 const { isForgeStarted } = require('core/forge-process');
 const { symbols } = require('core/ui');
 const debug = require('core/debug');
@@ -90,7 +90,7 @@ async function main({ args: [endpoint = ''], opts: { yes, chainName } }) {
           shell.echo(`${symbols.info} all state backup to ${bakDir}`);
           shell.exec(`mv ${oldDir} ${bakDir}`);
 
-          const keyDataPath = getChainKeyFilePath(chainName);
+          const keyDataPath = readChainKeyFilePath(chainName);
           debug(` rm -rf ${keyDataPath}`);
           shell.exec(`rm -rf ${keyDataPath}`);
         } else {

--- a/src/cli/node/upgrade/upgrade.js
+++ b/src/cli/node/upgrade/upgrade.js
@@ -49,9 +49,9 @@ function isStoppedToUpgrade(chainName) {
 }
 
 const execExceptionOnError = failedMessage => (...args) => {
-  const { code } = shell.exec(...args);
+  const { code, stderr } = shell.exec(...args);
   if (code !== 0) {
-    throw new Error(`${failedMessage}: ${code}`);
+    throw new Error(`${failedMessage}: ${stderr}, exit code: ${code}`);
   }
 };
 
@@ -63,9 +63,7 @@ const useNewVersion = (chainName, version) => {
     updateChainConfig(chainName, { version });
   }
 
-  execExceptionOnError('stop web failed')(`forge web stop -c ${chainName} --color always`, {
-    silent: true,
-  });
+  execExceptionOnError('stop web failed')(`forge web stop -c ${chainName} --color always`);
   execExceptionOnError('start forge failed')(`forge start ${chainName} --color always`);
 };
 

--- a/src/cli/node/upgrade/upgrade.js
+++ b/src/cli/node/upgrade/upgrade.js
@@ -14,7 +14,13 @@ const {
   printSuccess,
   strEqual,
 } = require('core/util');
-const { checkStartError, listReleases, updateChainConfig } = require('core/forge-fs');
+const {
+  checkStartError,
+  listReleases,
+  readChainConfigFromEnv,
+  updateChainConfig,
+  updateReleaseYaml,
+} = require('core/forge-fs');
 const { isForgeStartedByStarter } = require('core/forge-process');
 const debug = require('core/debug')('upgrade');
 
@@ -50,7 +56,13 @@ const execExceptionOnError = failedMessage => (...args) => {
 };
 
 const useNewVersion = (chainName, version) => {
-  updateChainConfig(chainName, { version });
+  const { name } = readChainConfigFromEnv();
+  if (name === chainName) {
+    updateReleaseYaml('forge', version);
+  } else {
+    updateChainConfig(chainName, { version });
+  }
+
   execExceptionOnError('stop web failed')(`forge web stop -c ${chainName} --color always`, {
     silent: true,
   });

--- a/src/cli/tools/web/web.js
+++ b/src/cli/tools/web/web.js
@@ -99,7 +99,7 @@ async function main({ args: [action = 'none'], opts }) {
     case 'stop':
       if (!pid) {
         shell.echo(`${symbols.info} forge web not started yet`);
-        process.exit(1);
+        process.exit(0);
         return;
       }
 

--- a/src/core/env.js
+++ b/src/core/env.js
@@ -237,11 +237,13 @@ function ensureRpcClient(args, chainName) {
     debug(`using forge-cli with remote node ${socketGrpc}`);
     Object.assign(config, forgeConfig);
   } else if (fs.existsSync(configPath)) {
-    if (process.env.FORGE_CONFIG) {
-      shell.echo(
-        `${symbols.info} ${chalk.yellow(`Using custom forge config: ${process.env.FORGE_CONFIG}`)}`
-      );
+    if (
+      process.env.FORGE_CONFIG &&
+      chainName === getChainNameFromForgeConfig(process.env.FORGE_CONFIG)
+    ) {
+      printInfo(`${chalk.yellow(`Using custom forge config: ${process.env.FORGE_CONFIG}`)}`);
     }
+
     const forgeConfig = parse(configPath);
     config.cli.forgeConfigPath = configPath;
     Object.assign(config, forgeConfig);

--- a/src/core/forge-config.js
+++ b/src/core/forge-config.js
@@ -432,15 +432,10 @@ async function ensureForgeRelease({
   return cliConfig;
 }
 
-function readChainConfig(chainName) {
-  return TOML.parse(fs.readFileSync(getChainReleaseFilePath(chainName)).toString());
-}
-
 module.exports = {
   copyReleaseConfig,
   ensureForgeRelease,
   getDefaultChainConfigs,
   setConfigToChain,
   setFilePathOfConfig,
-  readChainConfig,
 };

--- a/src/core/forge-fs.js
+++ b/src/core/forge-fs.js
@@ -28,11 +28,15 @@ const {
   REQUIRED_DIRS,
 } = require('../constant');
 
+const getChainNameFromForgeConfig = configPath => {
+  const config = TOML.parse(fs.readFileSync(configPath).toString());
+  return get(config, 'tendermint.genesis.chain_id', '');
+};
+
 const readChainConfigFromEnv = () => {
-  const configPath = process.env.FORGE_CONFIG_PATH;
+  const configPath = process.env.FORGE_CONFIG;
   if (configPath && fs.existsSync(configPath)) {
-    const config = TOML.parse(fs.readFileSync(configPath).toString());
-    return { name: get(config, 'app.name', ''), config, configPath };
+    return { name: getChainNameFromForgeConfig(configPath), configPath };
   }
 
   return {};
@@ -440,6 +444,7 @@ module.exports = {
   ensureChainDirectory,
   getAllAppDirectories,
   getAllChainNames,
+  getChainNameFromForgeConfig,
   getConsensusEnginBinPath,
   getCurrentReleaseFilePath,
   getDataDirectory,
@@ -457,13 +462,13 @@ module.exports = {
   getReleaseAssets,
   getRootConfigDirectory,
   readTendermintHomeDir,
+  getLocalVersions,
   getForgeVersionFromYaml,
   getOriginForgeReleaseFilePath,
   getForgeReleaseDirectory,
   getReleaseDirectory,
   getStorageEnginePath,
   readChainKeyFilePath,
-  getLocalVersions,
   isChainExists,
   isEmptyDirectory,
   isForgeBinExists,

--- a/src/core/forge-process.js
+++ b/src/core/forge-process.js
@@ -79,6 +79,7 @@ async function isForgeStopped(chainName = process.env.FORGE_CURRENT_CHAIN) {
 }
 
 async function getForgeProcessByTag(processName, chainName = process.env.FORGE_CURRENT_CHAIN) {
+  debug('getForgeProcessByTag, chain name:', chainName);
   const forgeProcesses = await findProcess('name', processName);
 
   const forgeProcess = forgeProcesses.find(
@@ -100,6 +101,7 @@ async function getForgeProcess(chainName = process.env.FORGE_CURRENT_CHAIN) {
 }
 
 async function getForgeWebProcess(chainName) {
+  debug('get forge web process, chain name:', chainName);
   return getForgeProcessByTag('web', chainName);
 }
 

--- a/src/core/forge-process.js
+++ b/src/core/forge-process.js
@@ -8,8 +8,7 @@ const { get } = require('lodash');
 const path = require('path');
 
 const debug = require('./debug')('forge-process');
-const { getTendermintHomeDir, getAllChainNames } = require('./forge-fs');
-const { readChainConfig } = require('./forge-config');
+const { readTendermintHomeDir, getAllChainNames, readChainConfig } = require('./forge-fs');
 const {
   escapseHomeDir,
   printError,
@@ -53,7 +52,7 @@ async function getTendermintProcess(chainName) {
     return result;
   }
 
-  const homeDir = escapseHomeDir(getTendermintHomeDir(chainName));
+  const homeDir = escapseHomeDir(readTendermintHomeDir(chainName));
 
   const tmp = tendermintProcess.find(({ cmd }) => cmd.includes(homeDir));
   if (tmp) {

--- a/src/core/libs/common.js
+++ b/src/core/libs/common.js
@@ -3,13 +3,8 @@
  */
 
 const semver = require('semver');
-const {
-  getAllChainNames,
-  getChainConfigPath,
-  getForgeVersionFromYaml,
-  listReleases,
-  updateReleaseYaml,
-} = require('../forge-fs');
+
+const { getAllChainNames, listReleases, updateReleaseYaml } = require('../forge-fs');
 const { engines } = require('../../../package');
 
 const DEFAULT_CHAIN_NAME_RETURN = { NO_CHAINS: 1 };
@@ -59,8 +54,10 @@ function getMinSupportForgeVersion() {
 }
 
 function getChainVersion(chainName) {
-  const currentVersion = getForgeVersionFromYaml(getChainConfigPath(chainName), 'version');
-  return currentVersion || '';
+  const allChainNames = getAllChainNames();
+  const chain = allChainNames.find(([name]) => name === chainName);
+
+  return chain ? chain[1].version : '';
 }
 
 module.exports = {

--- a/src/core/libs/global-config.js
+++ b/src/core/libs/global-config.js
@@ -1,9 +1,10 @@
 const pickBy = require('lodash/pickBy');
 const registryUrl = require('registry-url');
 const rcfile = require('rcfile');
+const os = require('os');
 
 function getDefaultGlobalConfig() {
-  return Object.assign({
+  return {
     allowMultiChain: true,
     autoUpgrade: true,
     configPath: undefined,
@@ -11,7 +12,7 @@ function getDefaultGlobalConfig() {
     mirror: undefined,
     moderatorSecretKey: undefined,
     npmRegistry: registryUrl(),
-  });
+  };
 }
 
 function getConfig(globalConfig = {}, defaultGlobalConfigs = {}) {
@@ -24,7 +25,7 @@ function getConfig(globalConfig = {}, defaultGlobalConfigs = {}) {
 }
 
 function getGlobalConfig() {
-  return getConfig(rcfile('forge'), getDefaultGlobalConfig());
+  return getConfig(rcfile('forge', { cwd: os.homedir() }), getDefaultGlobalConfig());
 }
 
 module.exports = { getGlobalConfig };

--- a/src/core/libs/global-config.js
+++ b/src/core/libs/global-config.js
@@ -6,6 +6,7 @@ function getDefaultGlobalConfig() {
   return Object.assign({
     allowMultiChain: true,
     autoUpgrade: true,
+    configPath: undefined,
     defaults: false,
     mirror: undefined,
     moderatorSecretKey: undefined,

--- a/src/core/libs/global-config.js
+++ b/src/core/libs/global-config.js
@@ -1,7 +1,6 @@
 const pickBy = require('lodash/pickBy');
 const registryUrl = require('registry-url');
 const rcfile = require('rcfile');
-const os = require('os');
 
 function getDefaultGlobalConfig() {
   return {
@@ -25,7 +24,7 @@ function getConfig(globalConfig = {}, defaultGlobalConfigs = {}) {
 }
 
 function getGlobalConfig() {
-  return getConfig(rcfile('forge', { cwd: os.homedir() }), getDefaultGlobalConfig());
+  return getConfig(rcfile('forge'), getDefaultGlobalConfig());
 }
 
 module.exports = { getGlobalConfig };


### PR DESCRIPTION
- fix: stop a not existed web should exit normally
- feat: make `--config-path` work again #172
- refact: read forge relative path from forge config file(forge_release.toml)